### PR TITLE
Avoid duplicate declaration error when a file already imports Vue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,7 @@ module.exports = function(contents) {
 
 function genHotReload (id) {
   return `
-if (module.hot) {
-  var options = __component__
+if (module.hot) {(function(options) {
   if (typeof options === 'function') {
     options = __component__.options
   }
@@ -63,6 +62,6 @@ if (module.hot) {
     } else {
       api.reload(${id}, options)
     }
-  }
+  }})(__component__)
 }`
 }


### PR DESCRIPTION
I hit an issue with one of my JS file that already import the Vue object causing a duplicate import, so I made this change as both `vue-loader` and `vue-template-loader` do this.

It seems to work really fine now, but maybe you could add a notice in readme to disable hmr from `vue-template-loader` when using both loaders.